### PR TITLE
fix: align numeric columns in leaderboard table with their headers

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -148,13 +148,13 @@ export default function Home() {
                 <div>{user.name}</div>
               </div>
             ),
-            <div className="text-right" key={`commits-${index}`}>
+            <div className="text-center" key={`commits-${index}`}>
               {user.commits}
             </div>,
-            <div className="text-right" key={`change-${index}`}>
+            <div className="text-center" key={`change-${index}`}>
               {user.changeScore.toFixed(2)}
             </div>,
-            <div className="text-right" key={`overall-${index}`}>
+            <div className="text-center" key={`overall-${index}`}>
               {user.overallScore.toFixed(2)}
             </div>,
           ]}


### PR DESCRIPTION
Fixes #15 
This pull request makes a small UI update to the `Home` page. The alignment of several columns in the user list has been changed from right-aligned to center-aligned, improving the visual consistency of the table.

- Changed the alignment of the `commits`, `changeScore`, and `overallScore` columns from `text-right` to `text-center` in the user list display in `page.tsx`.


<img width="1366" height="645" alt="Screenshot (1065)" src="https://github.com/user-attachments/assets/4fc9c007-8605-4afc-920d-f8c35f96a287" />