### PR TITLE
feat: update dynamic score calculations based on filter

### DIFF
--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -8,6 +8,7 @@ export interface FileData {
 export type CommitDetail = {
   message: string
   date: string // ISO string from GitHub commit
+  files?: FileData[]
 }
 
 export interface User {

--- a/src/utils/analyse-commits.ts
+++ b/src/utils/analyse-commits.ts
@@ -56,7 +56,18 @@ export const analyseCommits = (
     }
 
     user.commits.push(commitMsg)
-    user.commitDetails.push({ message: commitMsg, date: commitDate })
+    user.commitDetails.push({
+      message: commitMsg,
+      date: commitDate,
+      files: commitFiles
+        .filter((f) => !ignoreFilesPattern.test(f.filename))
+        .map((f) => ({
+          filename: f.filename,
+          additions: f.additions,
+          deletions: f.deletions,
+          changes: f.changes,
+        })),
+    })
     user.commitCount += 1
     user.changeScore += changeScore
     // applying log10 will help the leaderboard to not break when there are 1000+ additions

--- a/src/utils/filterCommitsByDate.ts
+++ b/src/utils/filterCommitsByDate.ts
@@ -1,4 +1,5 @@
 import { User } from "@/types/user"
+import { calculateChangeScore, calculateOverallScore } from "@/utils/scoring"
 
 export const filterCommitsByDate = (
   users: User[],
@@ -32,8 +33,20 @@ export const filterCommitsByDate = (
       // Recalculate commitCount
       const commitCount = filteredCommitDetails.length
 
-      const changeScore = user.changeScore
-      const overallScore = user.overallScore
+      // Recalculate changeScore from filtered commits
+      let changeScore = 0
+
+      for (const commit of filteredCommitDetails) {
+        // Each commit now has files with additions/deletions
+        if (commit.files) {
+          for (const file of commit.files) {
+            changeScore += calculateChangeScore(file.additions, file.deletions)
+          }
+        }
+      }
+
+      // Recalculate overallScore
+      const overallScore = calculateOverallScore(commitCount, changeScore)
 
       return {
         ...user,


### PR DESCRIPTION
This pull request introduces improvements to how commit details are tracked and how user scores are recalculated after filtering commits by date. The main changes include extending the commit detail structure to include file-level data and updating the scoring logic to use this granular information.

**Commit detail structure enhancements:**

* The `CommitDetail` type now optionally includes a `files` property, which contains an array of `FileData` objects representing the files changed in each commit.
* When analyzing commits, each entry in `user.commitDetails` is populated with the list of files changed, including their filename, additions, deletions, and changes, after filtering out ignored files.

**Scoring recalculation logic:**

* In the `filterCommitsByDate` utility, the recalculation of `changeScore` is now based on the additions and deletions of each file in the filtered commits, using the `calculateChangeScore` function.
* The `overallScore` is recalculated using the new `calculateOverallScore` function, ensuring scores reflect only the filtered commits.
* The necessary scoring functions are imported into `filterCommitsByDate.ts` to support the new logic.