### PR TITLE
fix: add installation instructions for project dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ docker run -d \
 
 - Make sure you have Docker installed
 
+Before starting the development server, install the project dependencies:
+
+```bash
+npm install
+# or
+yarn
+# or
+pnpm install
+```
+
 Then run the development server:
 
 ```bash


### PR DESCRIPTION
Fixes #14 
This pull request updates the setup instructions in the `README.md` to clarify that project dependencies need to be installed before starting the development server.

* Setup instructions improvement:
  * Added a step to install dependencies (`npm install`, `yarn`, or `pnpm install`) before running the development server in the `README.md`.