### PR TITLE
Feature : Add “Last Month” Leaderboard Filter Option

### DIFF
--- a/src/app/api/leaderboard/[range]/route.ts
+++ b/src/app/api/leaderboard/[range]/route.ts
@@ -6,7 +6,7 @@ import { NextRequest } from "next/server"
 
 export async function GET(request: NextRequest, ctx: RouteContext<"/api/leaderboard/[range]">) {
   const params = await ctx.params
-  const validRanges = ["daily", "weekly", "monthly", "yearly", "all"]
+  const validRanges = ["daily", "weekly", "monthly", "yearly", "last-month", "all"]
   const range = validRanges.includes(params.range) ? params.range : "all"
 
   let leaders = (await redis.get("leaders")) as User[] | null
@@ -15,7 +15,10 @@ export async function GET(request: NextRequest, ctx: RouteContext<"/api/leaderbo
   if (!leaders) return Response.json({ body: "Cannot fetch leaderboard now" }, { status: 503 })
 
   if (range !== "all") {
-    leaders = filterCommitsByDate(leaders, range as "daily" | "weekly" | "monthly" | "yearly")
+    leaders = filterCommitsByDate(
+      leaders,
+      range as "daily" | "weekly" | "monthly" | "yearly" | "last-month",
+    )
   }
 
   return Response.json(

--- a/src/components/LeaderboardFilter.tsx
+++ b/src/components/LeaderboardFilter.tsx
@@ -12,6 +12,7 @@ const LeaderboardFilter: FC<Props> = ({ value, onChange }) => {
       <option value="daily">Today</option>
       <option value="weekly">This Week</option>
       <option value="monthly">This Month</option>
+      <option value="last-month">Last Month</option>
       <option value="yearly">This Year</option>
     </select>
   )

--- a/src/utils/filterCommitsByDate.ts
+++ b/src/utils/filterCommitsByDate.ts
@@ -3,7 +3,7 @@ import { calculateChangeScore, calculateOverallScore } from "@/utils/scoring"
 
 export const filterCommitsByDate = (
   users: User[],
-  type: "daily" | "weekly" | "monthly" | "yearly",
+  type: "daily" | "weekly" | "monthly" | "yearly" | "last-month",
 ) => {
   const now = new Date()
   let from: Date
@@ -18,6 +18,9 @@ export const filterCommitsByDate = (
     case "monthly":
       from = new Date(now.getFullYear(), now.getMonth(), 1)
       break
+    case "last-month":
+      from = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+      break
     case "yearly":
       from = new Date(now.getFullYear(), 0, 1)
       break
@@ -28,7 +31,13 @@ export const filterCommitsByDate = (
   return users
     .map((user) => {
       // Filter commitDetails by date
-      const filteredCommitDetails = user.commitDetails.filter((c) => new Date(c.date) >= from)
+      const filteredCommitDetails = user.commitDetails.filter((c) => {
+        const date = new Date(c.date)
+        if (type === "last-month") {
+          return date >= from && date < new Date(now.getFullYear(), now.getMonth(), 1)
+        }
+        return date >= from
+      })
 
       // Recalculate commitCount
       const commitCount = filteredCommitDetails.length


### PR DESCRIPTION
This pull request adds support for a new "Last Month" filter to the leaderboard feature, allowing users to view leaderboard data specifically for the previous month. The changes ensure that this new filter is available in the UI, handled correctly in the API, and accurately filters commit data.

**Leaderboard filter enhancements:**

* Added "Last Month" as an option in the `LeaderboardFilter` component so users can select it from the dropdown.

**API and backend support:**

* Updated the API route (`src/app/api/leaderboard/[range]/route.ts`) to recognize "last-month" as a valid leaderboard range and pass it to the filtering logic.
* Extended the `filterCommitsByDate` utility to accept "last-month" as a valid range type.
* Implemented logic in `filterCommitsByDate` to filter commit details specifically for the previous month, ensuring accurate leaderboard results.

> [!WARNING]
> I do not have a GitHub Token for the organization, so I was unable to run this code locally. While the implementation logic follows the expected pattern, I cannot guarantee functionality without this access. **A person with access to a GitHub token may need to execute the code and verify functionality.**