### PR TITLE
Exclude apps from leadeboard

### DIFF
--- a/src/utils/analyse-commits.ts
+++ b/src/utils/analyse-commits.ts
@@ -34,7 +34,7 @@ export const analyseCommits = (
     if (!authorName) continue
 
     // Exclude bots/apps by checking against a list of patterns
-    const excludePatterns = ["bot", "app"]
+    const excludePatterns = ["[bot]", "[app]"]
     if (excludePatterns.some((pattern) => authorName.toLowerCase().includes(pattern))) continue
 
     let user = results.find((u) => u.name === authorName)


### PR DESCRIPTION
Done 🙌🏻

Added logic to skip authors whose names contain "bot" or "app" (case-insensitive), preventing bot/app commits from affecting analysis.
`src/utils/analyse-commits.ts`
```ts
36 +   // Exclude bots/apps by checking against a list of patterns
37 + const excludePatterns = ["bot", "app"]
38 + if (excludePatterns.some((pattern) => authorName.toLowerCase().includes(pattern))) continue
39 +
```